### PR TITLE
Fix topbar props + HUD Controls + Fix overlay not staying on top

### DIFF
--- a/src/UI/App.tsx
+++ b/src/UI/App.tsx
@@ -3,6 +3,7 @@ import { Dashboard } from "./pages/Dashboard/Dashboard";
 import { MatchesPage } from "./pages/Matches/MatchPage";
 import { PlayersPage } from "./pages/Players/PlayersPage";
 import { TeamsPage } from "./pages/Teams/TeamsPage";
+import { HUDPage } from "./pages/HUD/HUDPage";
 import { AppProviders } from "./context/AppProviders";
 import { Layout } from "./pages/Layout";
 
@@ -16,6 +17,7 @@ const AuthenticatedRoutes = () => (
           <Route path="players" element={<PlayersPage />} />
           <Route path="teams" element={<TeamsPage />} />
           <Route path="dashboard" element={<Dashboard />} />
+          <Route path="hud" element={<HUDPage />} />
         </Route>
       </Routes>
     </MemoryRouter>

--- a/src/UI/pages/HUD/HUDPage.tsx
+++ b/src/UI/pages/HUD/HUDPage.tsx
@@ -1,0 +1,217 @@
+import { useState, useEffect } from "react";
+import { Container, ButtonContained } from "../../components";
+import { MdPlayArrow, MdStop, MdVisibility, MdVisibilityOff } from "react-icons/md";
+
+export const HUDPage = () => {
+  const [hudStatus, setHudStatus] = useState<'closed' | 'visible' | 'hidden' | 'minimized'>('closed');
+  const [displays, setDisplays] = useState<DisplayInfo[]>([]);
+  const [selectedDisplay, setSelectedDisplay] = useState<number>(0);
+
+  useEffect(() => {
+    // Get available displays from Electron
+    const loadDisplays = async () => {
+      try {
+        const availableDisplays = await window.electron.getDisplays();
+        setDisplays(availableDisplays);
+      } catch (error) {
+        console.error('Failed to load displays:', error);
+        // Fallback to mock data if IPC fails
+        const mockDisplays: DisplayInfo[] = [
+          { id: 0, label: "Primary Display (1920x1080)", bounds: { x: 0, y: 0, width: 1920, height: 1080 }, primary: true },
+        ];
+        setDisplays(mockDisplays);
+      }
+    };
+    
+    loadDisplays();
+  }, []);
+
+  useEffect(() => {
+    // Check HUD status periodically and sync with UI
+    const checkHudStatus = async () => {
+      try {
+        const status = await window.electron.getHudStatus();
+        setHudStatus(status as 'closed' | 'visible' | 'hidden' | 'minimized');
+      } catch (error) {
+        console.error('Failed to get HUD status:', error);
+      }
+    };
+
+    // Check status immediately
+    checkHudStatus();
+
+    // Then check every 2 seconds
+    const interval = setInterval(checkHudStatus, 2000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const startHUD = () => {
+    window.electron.startOverlay();
+  };
+
+  const closeHUD = () => {
+    window.electron.closeOverlay();
+  };
+
+  const toggleHUD = () => {
+    window.electron.toggleOverlay();
+  };
+
+  const moveToDisplay = (displayId: number) => {
+    window.electron.moveHudToDisplay(displayId);
+    setSelectedDisplay(displayId);
+  };
+
+  return (
+    <section className="relative flex size-full flex-col gap-1">
+      <div className="sticky top-0 z-10 flex h-16 w-full shrink-0 items-center justify-center bg-background-primary px-2">
+        <div className="flex w-full items-center justify-between">
+          <h3 className="noDrag capitalize">HUD Overlay Controls</h3>
+        </div>
+      </div>
+      <Container>
+        <div className="flex flex-col gap-6 p-6">
+        
+        {/* HUD Status */}
+        <div className="rounded-lg bg-background-secondary p-4">
+          <h3 className="mb-3 text-lg font-semibold text-text">HUD Status</h3>
+          <div className="flex items-center gap-3">
+            <div className={`h-3 w-3 rounded-full ${
+              hudStatus === 'visible' ? 'bg-green-500' : 
+              hudStatus === 'hidden' ? 'bg-yellow-500' : 
+              hudStatus === 'minimized' ? 'bg-blue-500' : 
+              'bg-gray-500'
+            }`} />
+            <span className="text-text-secondary">
+              {hudStatus === 'visible' ? 'Visible & Active' :
+               hudStatus === 'hidden' ? 'Hidden' :
+               hudStatus === 'minimized' ? 'Minimized' :
+               'Not Running'}
+            </span>
+          </div>
+        </div>
+
+        {/* HUD Controls */}
+        <div className="rounded-lg bg-background-secondary p-4">
+          <h3 className="mb-4 text-lg font-semibold text-text">Controls</h3>
+          <div className="flex flex-wrap gap-3">
+            
+            <ButtonContained
+              onClick={startHUD}
+              disabled={hudStatus === 'visible'}
+              className="flex items-center gap-2"
+            >
+              <MdPlayArrow className="size-5" />
+              Start HUD
+            </ButtonContained>
+
+            <ButtonContained
+              onClick={toggleHUD}
+              disabled={hudStatus === 'closed'}
+              className="flex items-center gap-2"
+            >
+              {hudStatus === 'visible' ? (
+                <>
+                  <MdVisibilityOff className="size-5" />
+                  Hide HUD
+                </>
+              ) : (
+                <>
+                  <MdVisibility className="size-5" />
+                  Show HUD
+                </>
+              )}
+            </ButtonContained>
+
+            <ButtonContained
+              onClick={closeHUD}
+              disabled={hudStatus === 'closed'}
+              className="flex items-center gap-2"
+            >
+              <MdStop className="size-5" />
+              Close HUD
+            </ButtonContained>
+
+          </div>
+        </div>
+
+        {/* Display Selection */}
+        <div className="rounded-lg bg-background-secondary p-4">
+          <h3 className="mb-4 text-lg font-semibold text-text">Display Selection</h3>
+          <div className="flex flex-col gap-3">
+            <p className="text-sm text-text-secondary">
+              Choose which display to show the HUD overlay on:
+            </p>
+            
+            <select 
+              value={selectedDisplay} 
+              onChange={(e) => setSelectedDisplay(Number(e.target.value))}
+              className="rounded-lg border border-border bg-background-primary p-2 text-text"
+            >
+              {displays.map((display) => (
+                <option key={display.id} value={display.id}>
+                  {display.label}
+                </option>
+              ))}
+            </select>
+
+            <ButtonContained
+              onClick={() => moveToDisplay(selectedDisplay)}
+              disabled={hudStatus === 'closed'}
+              className="w-fit"
+            >
+              Move HUD to Selected Display
+            </ButtonContained>
+          </div>
+        </div>
+
+        {/* Keyboard Shortcuts Info */}
+        <div className="rounded-lg bg-background-secondary p-4">
+          <h3 className="mb-4 text-lg font-semibold text-text">Global Keyboard Shortcuts</h3>
+          <div className="grid grid-cols-1 gap-2 text-sm md:grid-cols-2">
+            <div className="flex justify-between">
+              <span className="text-text-secondary">Focus HUD (Make Interactive):</span>
+              <span className="font-mono text-text">Ctrl+Alt+H</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-text-secondary">Close HUD:</span>
+              <span className="font-mono text-text">Ctrl+Alt+C</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-text-secondary">Toggle HUD Visibility:</span>
+              <span className="font-mono text-text">Ctrl+Alt+X</span>
+            </div>
+          </div>
+          <div className="mt-4 rounded-lg bg-background-light p-3">
+            <h4 className="mb-2 text-sm font-semibold text-text">When HUD is Interactive:</h4>
+            <div className="grid grid-cols-1 gap-1 text-xs md:grid-cols-2">
+              <div className="flex justify-between">
+                <span className="text-text-secondary">Exit Interactive Mode:</span>
+                <span className="font-mono text-text">Escape</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-text-secondary">Close HUD:</span>
+                <span className="font-mono text-text">Ctrl+Shift+C</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Tips */}
+        <div className="rounded-lg bg-background-light p-4">
+          <h3 className="mb-2 text-lg font-semibold text-text">Tips</h3>
+          <ul className="space-y-1 text-sm text-text-secondary">
+            <li>• The HUD overlay appears fullscreen and stays on top of all applications</li>
+            <li>• Use Ctrl+Alt+H to make the HUD interactive (allows mouse input)</li>
+            <li>• In interactive mode, you can move and control the HUD window</li>
+            <li>• Press Escape to return to click-through mode</li>
+            <li>• Global shortcuts work from any application, even when HUD is click-through</li>
+          </ul>
+        </div>
+
+        </div>
+      </Container>
+    </section>
+  );
+};

--- a/src/UI/pages/MainPanel/Topbar.tsx
+++ b/src/UI/pages/MainPanel/Topbar.tsx
@@ -7,8 +7,8 @@ interface TopBarProps {
   header: string;
   buttonText?: string;
   openForm?: (open: boolean) => void;
-  layout: "card" | "table";
-  setLayout: (layout: "card" | "table") => void;
+  layout?: "card" | "table";
+  setLayout?: (layout: "card" | "table") => void;
 }
 
 export const Topbar = ({
@@ -52,12 +52,12 @@ export const Topbar = ({
           {location.pathname === "/players" &&
             (layout == "card" ? (
               <MdOutlineTableRows
-                onClick={() => setLayout("table")}
+                onClick={() => setLayout?.("table")}
                 className="flex size-12 cursor-pointer items-center justify-center self-end rounded-lg p-2 hover:bg-background-light"
               />
             ) : (
               <MdOutlineRememberMe
-                onClick={() => setLayout("card")}
+                onClick={() => setLayout?.("card")}
                 className="flex size-12 cursor-pointer items-center justify-center self-end rounded-lg p-2 hover:bg-background-light"
               />
             ))}

--- a/src/UI/pages/Sidebar/RouteSelect.tsx
+++ b/src/UI/pages/Sidebar/RouteSelect.tsx
@@ -5,6 +5,7 @@ import {
   MdGroups,
   MdDashboard,
   MdAddCircle,
+  MdDesktopWindows,
   MdPlayArrow,
 } from "react-icons/md";
 import { useDrawer } from "../../hooks";
@@ -22,6 +23,7 @@ const routes: RouteProps[] = [
   { Icon: MdOutlinePerson, title: "Players", to: "players" },
   { Icon: MdGroups, title: "Teams", to: "teams" },
   { Icon: MdDashboard, title: "Dashboard", to: "dashboard" },
+  { Icon: MdDesktopWindows, title: "HUD Overlay", to: "hud" },
 ];
 
 export const RouteSelect = () => {
@@ -38,7 +40,7 @@ export const RouteSelect = () => {
             onClick={() => window.electron.startOverlay()}
           >
             <MdPlayArrow className="absolute left-3.5 size-7" />
-            {isOpen && <p className="pl-14 font-semibold">Overlay</p>}
+            {isOpen && <p className="pl-14 font-semibold">Start Overlay</p>}
           </button>
         </div>
       </div>

--- a/src/electron/hudWindow.ts
+++ b/src/electron/hudWindow.ts
@@ -1,25 +1,171 @@
-import { BrowserWindow } from "electron";
+import { BrowserWindow, screen, globalShortcut } from "electron";
 import { getHudPath, getPreloadPath } from "./helpers/index.js";
 import { checkDirectories } from "./helpers/util.js";
 import path from "path";
 
+let hudWindow: BrowserWindow | null = null;
+let isIgnoringMouse = true;
+
 export function createHudWindow() {
-  const hudWindow = new BrowserWindow({
+  if (hudWindow) {
+    hudWindow.focus();
+    return hudWindow;
+  }
+
+  hudWindow = new BrowserWindow({
     fullscreen: true,
     transparent: true,
     alwaysOnTop: true,
     resizable: false,
     focusable: true,
     frame: false,
+    skipTaskbar: true,
     webPreferences: {
       preload: getPreloadPath(),
       backgroundThrottling: false,
+      nodeIntegration: false,
+      contextIsolation: true,
     },
   });
 
   checkDirectories();
   hudWindow.loadFile(path.join(getHudPath(), "index.html"));
   hudWindow.setIgnoreMouseEvents(true);
+  isIgnoringMouse = true;
+  
+  // Force the window to stay on top with highest level
+  hudWindow.setAlwaysOnTop(true, 'screen-saver');
+  
+  // Ensure it stays on top when other windows are focused
+  hudWindow.on('blur', () => {
+    if (hudWindow) {
+      hudWindow.setAlwaysOnTop(true, 'screen-saver');
+    }
+  });
+
+  // Clean up reference when closed
+  hudWindow.on('closed', () => {
+    hudWindow = null;
+  });
+
+  // Add keyboard shortcuts for HUD control
+  hudWindow.webContents.on('before-input-event', (event, input) => {
+    if (!hudWindow) return;
+    
+    // Ctrl+Shift+H: Toggle HUD interaction mode
+    if (input.control && input.shift && input.key.toLowerCase() === 'h') {
+      isIgnoringMouse = !isIgnoringMouse;
+      hudWindow.setIgnoreMouseEvents(isIgnoringMouse);
+      hudWindow.setFocusable(!isIgnoringMouse);
+      if (!isIgnoringMouse) {
+        hudWindow.focus();
+      }
+    }
+    
+    // Escape: Exit interaction mode
+    if (input.key === 'Escape') {
+      hudWindow.setIgnoreMouseEvents(true);
+      hudWindow.setFocusable(false);
+      isIgnoringMouse = true;
+    }
+    
+    // Ctrl+Shift+C: Close HUD
+    if (input.control && input.shift && input.key.toLowerCase() === 'c') {
+      hudWindow.close();
+    }
+    
+    // Ctrl+Shift+M: Move to next screen
+    if (input.control && input.shift && input.key.toLowerCase() === 'm') {
+      moveHudToNextScreen();
+    }
+    
+    // Ctrl+Shift+X: Toggle minimize/restore
+    if (input.control && input.shift && input.key.toLowerCase() === 'x') {
+      if (hudWindow.isMinimized()) {
+        hudWindow.restore();
+        hudWindow.setAlwaysOnTop(true, 'screen-saver');
+      } else {
+        hudWindow.minimize();
+      }
+    }
+  });
 
   return hudWindow;
+}
+
+export function moveHudToDisplay(displayIndex: number) {
+  if (!hudWindow) return false;
+  
+  const displays = screen.getAllDisplays();
+  if (displayIndex < 0 || displayIndex >= displays.length) return false;
+  
+  const targetDisplay = displays[displayIndex];
+  
+  // Move to the target display
+  hudWindow.setBounds({
+    x: targetDisplay.bounds.x,
+    y: targetDisplay.bounds.y,
+    width: targetDisplay.bounds.width,
+    height: targetDisplay.bounds.height
+  });
+  
+  return true;
+}
+
+export function getAvailableDisplays() {
+  const primary = screen.getPrimaryDisplay();
+  return screen.getAllDisplays().map((display, index) => ({
+    id: index,
+    label: `Display ${index + 1} (${display.bounds.width}x${display.bounds.height})${display.id === primary.id ? ' - Primary' : ''}`,
+    bounds: display.bounds,
+    primary: display.id === primary.id
+  }));
+}
+
+function moveHudToNextScreen() {
+  if (!hudWindow) return;
+  
+  const displays = screen.getAllDisplays();
+  
+  if (displays.length <= 1) return;
+  
+  const currentBounds = hudWindow.getBounds();
+  const currentDisplay = screen.getDisplayMatching(currentBounds);
+  const currentIndex = displays.findIndex(d => d.id === currentDisplay.id);
+  const nextIndex = (currentIndex + 1) % displays.length;
+  const nextDisplay = displays[nextIndex];
+  
+  // Move to the next display
+  hudWindow.setBounds({
+    x: nextDisplay.bounds.x,
+    y: nextDisplay.bounds.y,
+    width: nextDisplay.bounds.width,
+    height: nextDisplay.bounds.height
+  });
+}
+
+export function getHudWindow() {
+  return hudWindow;
+}
+
+export function closeHudWindow() {
+  if (hudWindow) {
+    hudWindow.close();
+  }
+}
+
+export function getHudStatus() {
+  if (!hudWindow) {
+    return 'closed';
+  }
+  
+  if (hudWindow.isMinimized()) {
+    return 'minimized';
+  }
+  
+  if (hudWindow.isVisible()) {
+    return 'visible';
+  }
+  
+  return 'hidden';
 }

--- a/src/electron/ipcEvents/ipMainEvents.ts
+++ b/src/electron/ipcEvents/ipMainEvents.ts
@@ -4,7 +4,7 @@ import {
   ipcMainOn,
   openHudsDirectory,
 } from "../helpers/index.js";
-import { createHudWindow } from "../hudWindow.js";
+import { createHudWindow, getHudWindow, closeHudWindow, moveHudToDisplay, getAvailableDisplays, getHudStatus } from "../hudWindow.js";
 import { getPlayers } from "../server/services/index.js";
 // Handle expects a response
 export function ipcMainEvents(mainWindow: BrowserWindow) {
@@ -38,11 +38,42 @@ export function ipcMainEvents(mainWindow: BrowserWindow) {
     hudWindow.show();
   });
 
+  ipcMainOn("closeOverlay", () => {
+    closeHudWindow();
+  });
+
+  ipcMainOn("toggleOverlay", () => {
+    const hudWindow = getHudWindow();
+    if (hudWindow) {
+      if (hudWindow.isVisible()) {
+        hudWindow.hide();
+      } else {
+        hudWindow.show();
+      }
+    } else {
+      const newHudWindow = createHudWindow();
+      newHudWindow.show();
+    }
+  });
+
   ipcMainOn("openExternalLink", (url) => {
     shell.openExternal(url);
   });
 
   ipcMainOn("openHudsDirectory", () => {
     openHudsDirectory();
+  });
+
+  // HUD display management  
+  ipcMainHandle("getDisplays", () => {
+    return getAvailableDisplays();
+  });
+
+  ipcMainOn("moveHudToDisplay", (displayIndex: number) => {
+    moveHudToDisplay(displayIndex);
+  });
+
+  ipcMainHandle("getHudStatus", () => {
+    return getHudStatus();
   });
 }

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow } from "electron";
+import { app, BrowserWindow, globalShortcut } from "electron";
 import {
   checkDirectories,
   isDev,
@@ -9,6 +9,7 @@ import {
 import { shutDown, startServer } from "./server/server.js";
 import { createTray } from "./tray.js";
 import { createMenu } from "./menu.js";
+import { getHudWindow, closeHudWindow } from "./hudWindow.js";
 import http from "http";
 import { ipcMainEvents } from "./ipcEvents/index.js";
 
@@ -23,6 +24,12 @@ app.on("ready", () => {
   createMenu(mainWindow);
   handleCloseEvents(mainWindow);
   ipcMainEvents(mainWindow);
+  registerGlobalHudShortcuts();
+});
+
+app.on("will-quit", () => {
+  // Unregister all global shortcuts
+  globalShortcut.unregisterAll();
 });
 
 function createMainWindow() {
@@ -71,4 +78,47 @@ function handleCloseEvents(mainWindow: BrowserWindow) {
   mainWindow.on("show", () => {
     willClose = false;
   });
+}
+
+function registerGlobalHudShortcuts() {
+  // Register global shortcuts for HUD control
+  try {
+    // Ctrl+Alt+H: Focus HUD (makes it interactive)
+    globalShortcut.register('CommandOrControl+Alt+H', () => {
+      const hudWindow = getHudWindow();
+      if (hudWindow) {
+        hudWindow.setIgnoreMouseEvents(false);
+        hudWindow.setFocusable(true);
+        hudWindow.focus();
+        hudWindow.webContents.executeJavaScript(`
+          console.log('HUD is now interactive - use Ctrl+Shift+C to close, Escape to return to click-through');
+        `);
+      }
+    });
+
+    // Ctrl+Alt+C: Close HUD
+    globalShortcut.register('CommandOrControl+Alt+C', () => {
+      closeHudWindow();
+    });
+
+    // Ctrl+Alt+X: Toggle HUD visibility
+    globalShortcut.register('CommandOrControl+Alt+X', () => {
+      const hudWindow = getHudWindow();
+      if (hudWindow) {
+        if (hudWindow.isVisible()) {
+          hudWindow.hide();
+        } else {
+          hudWindow.show();
+        }
+      }
+    });
+
+    console.log('Global HUD shortcuts registered:');
+    console.log('- Ctrl+Alt+H: Focus HUD (make interactive)');
+    console.log('- Ctrl+Alt+C: Close HUD');  
+    console.log('- Ctrl+Alt+X: Toggle HUD visibility');
+    
+  } catch (error) {
+    console.error('Failed to register global shortcuts:', error);
+  }
 }

--- a/src/electron/preload.cts
+++ b/src/electron/preload.cts
@@ -16,9 +16,14 @@ electron.contextBridge.exposeInMainWorld("electron", {
     ipcSend("sendFrameAction", payload);
   },
 
-  startOverlay: () => ipcSend("startOverlay", null),
+  startOverlay: () => ipcSend("startOverlay", undefined),
+  closeOverlay: () => ipcSend("closeOverlay", undefined),
+  toggleOverlay: () => ipcSend("toggleOverlay", undefined),
   openExternalLink: (url) => ipcSend("openExternalLink", url),
   openHudsDirectory: () => ipcSend("openHudsDirectory", undefined),
+  getDisplays: () => ipcInvoke("getDisplays"),
+  moveHudToDisplay: (displayIndex) => ipcSend("moveHudToDisplay", displayIndex),
+  getHudStatus: () => ipcInvoke("getHudStatus"),
 } satisfies Window["electron"]);
 
 function ipcInvoke<Key extends keyof EventPayloadMapping>(

--- a/src/electron/tray.ts
+++ b/src/electron/tray.ts
@@ -1,6 +1,7 @@
-import { app, BrowserWindow, Menu, Tray } from "electron";
+import { app, BrowserWindow, Menu, Tray, screen } from "electron";
 import path from "path";
 import { getAssetPath } from "./helpers/index.js";
+import { createHudWindow, getHudWindow, closeHudWindow } from "./hudWindow.js";
 
 export function createTray(mainWindow: BrowserWindow) {
   /* 
@@ -11,22 +12,117 @@ export function createTray(mainWindow: BrowserWindow) {
 
   const tray = new Tray(path.join(getAssetPath(), "icon.png"));
 
-  tray.setContextMenu(
-    /* Tray menu items */
-    Menu.buildFromTemplate([
-      {
-        label: "Show",
-        click: () => {
-          mainWindow.show();
-          if (app.dock) {
-            app.dock.show();
-          }
+  const updateTrayMenu = () => {
+    const hudWindow = getHudWindow();
+    const hudExists = hudWindow !== null;
+    const hudVisible = hudExists && hudWindow.isVisible();
+    
+    tray.setContextMenu(
+      Menu.buildFromTemplate([
+        {
+          label: "Show Main Window",
+          click: () => {
+            mainWindow.show();
+            if (app.dock) {
+              app.dock.show();
+            }
+          },
         },
-      },
-      {
-        label: "Quit",
-        click: () => app.quit(),
-      },
-    ]),
-  );
+        { type: "separator" },
+        {
+          label: "HUD Overlay",
+          submenu: [
+            {
+              label: hudExists ? "Show HUD" : "Start HUD",
+              enabled: !hudVisible,
+              click: () => {
+                if (hudExists) {
+                  hudWindow.show();
+                } else {
+                  const newHudWindow = createHudWindow();
+                  newHudWindow.show();
+                }
+                // Update menu after HUD state changes
+                setTimeout(updateTrayMenu, 100);
+              },
+            },
+            {
+              label: "Hide HUD",
+              enabled: hudVisible,
+              click: () => {
+                if (hudWindow) {
+                  hudWindow.hide();
+                }
+                setTimeout(updateTrayMenu, 100);
+              },
+            },
+            {
+              label: "Close HUD",
+              enabled: hudExists,
+              click: () => {
+                closeHudWindow();
+                setTimeout(updateTrayMenu, 100);
+              },
+            },
+            { type: "separator" },
+            {
+              label: "Move to Next Screen",
+              enabled: hudExists,
+              click: () => {
+                if (hudWindow) {
+                  moveHudToNextScreen(hudWindow);
+                }
+              },
+            },
+            {
+              label: hudExists && hudWindow.isMinimized() ? "Restore HUD" : "Minimize HUD",
+              enabled: hudExists,
+              click: () => {
+                if (hudWindow) {
+                  if (hudWindow.isMinimized()) {
+                    hudWindow.restore();
+                    hudWindow.setAlwaysOnTop(true, 'screen-saver');
+                  } else {
+                    hudWindow.minimize();
+                  }
+                }
+                setTimeout(updateTrayMenu, 100);
+              },
+            },
+          ],
+        },
+        { type: "separator" },
+        {
+          label: "Quit",
+          click: () => app.quit(),
+        },
+      ])
+    );
+  };
+
+  // Initial menu setup
+  updateTrayMenu();
+  
+  // Update menu every few seconds to keep it current
+  setInterval(updateTrayMenu, 2000);
+}
+
+function moveHudToNextScreen(hudWindow: BrowserWindow) {
+  const displays = screen.getAllDisplays();
+  
+  if (displays.length <= 1) return;
+  
+  const currentBounds = hudWindow.getBounds();
+  const currentDisplay = screen.getDisplayMatching(currentBounds);
+  const currentIndex = displays.findIndex(d => d.id === currentDisplay.id);
+  const nextIndex = (currentIndex + 1) % displays.length;
+  const nextDisplay = displays[nextIndex];
+  
+  // Move to the next display
+  hudWindow.setBounds({
+    x: nextDisplay.bounds.x,
+    y: nextDisplay.bounds.y,
+    width: nextDisplay.bounds.width,
+    height: nextDisplay.bounds.height
+  });
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -3,8 +3,13 @@ interface Window {
     startServer: (callback: (message: string) => void) => void;
     sendFrameAction: (payload: FrameWindowAction) => void;
     startOverlay: () => void;
+    closeOverlay: () => void;
+    toggleOverlay: () => void;
     openExternalLink: (url: string) => void;
     openHudsDirectory: () => void;
+    getDisplays: () => Promise<DisplayInfo[]>;
+    moveHudToDisplay: (displayIndex: number) => void;
+    getHudStatus: () => Promise<string>;
   };
   update: {
     updateMessage: (callback: (message: string) => void) => void;
@@ -22,12 +27,17 @@ interface Window {
 
 type EventPayloadMapping = {
   startServer: string;
-  startOverlay;
+  startOverlay: void;
+  closeOverlay: void;
+  toggleOverlay: void;
   sendFrameAction: FrameWindowAction;
   openExternalLink: string;
   getPlayers: Promise<Player[]>;
   updateMessage: string;
   openHudsDirectory: void;
+  getDisplays: DisplayInfo[];
+  moveHudToDisplay: number;
+  getHudStatus: string;
 };
 
 type FrameWindowAction =
@@ -209,3 +219,15 @@ type Knife =
   | "knife_ursus" //
   | "knife_widowmaker" //
   | "knife_canis"; //
+
+interface DisplayInfo {
+  id: number;
+  label: string;
+  bounds: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+  primary: boolean;
+}


### PR DESCRIPTION
Fixed topbar props #34 
Fixed overlay not staying on top #35 
Implemented a HUD control page and shortcuts, to Show/Hide HUD, move it to another screen, and keyboard shortcuts for these actions