### PR TITLE
Add manual match result editing and HUD link copy

### DIFF
--- a/src/UI/components/Container.tsx
+++ b/src/UI/components/Container.tsx
@@ -4,9 +4,16 @@ interface ContainerProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
 }
 
-export const Container = ({ children }: ContainerProps) => {
+export const Container = ({
+  children,
+  className = "",
+  ...rest
+}: ContainerProps) => {
   return (
-    <div className="container flex h-full flex-col items-center overflow-x-hidden">
+    <div
+      className={`container flex h-full min-h-0 flex-col overflow-hidden ${className}`.trim()}
+      {...rest}
+    >
       {children}
     </div>
   );

--- a/src/UI/components/Dialog.tsx
+++ b/src/UI/components/Dialog.tsx
@@ -18,7 +18,7 @@ export const Dialog = ({ children, onClose, open }: DialogProps) => {
         className="fixed bottom-0 left-0 right-0 top-0 z-30 bg-black/70"
         onClick={onClose}
       />
-      <div className="container fixed left-1/2 top-1/2 z-30 flex max-h-[90vh] -translate-x-1/2 -translate-y-1/2 flex-col rounded border border-border bg-background-primary p-4 text-text">
+      <div className="container fixed left-1/2 top-1/2 z-30 flex h-[90vh] w-[min(96vw,1400px)] min-h-0 -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded border border-border bg-background-primary p-4 text-text">
         <button
           className="z-4 absolute right-4 top-4 hover:text-gray-400"
           onClick={onClose}

--- a/src/UI/pages/Matches/MatchForm.tsx
+++ b/src/UI/pages/Matches/MatchForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { MatchTypes } from "./MatchPage";
 import { VetoRow } from "./VetoRow";
 import { ButtonContained, Container, Dialog } from "../../components";
@@ -10,11 +10,19 @@ interface MatchFormProps {
   setOpen: (open: boolean) => void;
 }
 
+const createEmptyVeto = (): Veto => ({
+  type: "ban",
+  teamId: "",
+  mapName: "",
+  side: "NO",
+  reverseSide: false,
+  mapEnd: false,
+});
+
 export const MatchForm = ({ open, setOpen }: MatchFormProps) => {
   const {
   isEditing,
   selectedMatch,
-  setCurrentMatch,
     createMatch,
     updateMatch,
     setIsEditing,
@@ -34,31 +42,47 @@ export const MatchForm = ({ open, setOpen }: MatchFormProps) => {
   const [vetos, setVetos] = useState<Veto[]>(
     Array(9)
       .fill(null)
-      .map(() => ({
-        teamId: "",
-        mapName: "",
-        side: "NO",
-        type: "ban",
-        mapEnd: false,
-      })),
+      .map(() => createEmptyVeto()),
   );
+  const loadedMatchIdRef = useRef<string | null>(null);
 
   const leftTeam = teams.find((team) => team._id === leftTeamId);
   const rightTeam = teams.find((team) => team._id === rightTeamId);
 
+  const clearFormState = () => {
+    setLeftTeamId(null);
+    setRightTeamId(null);
+    setMatchType("bo1");
+    setLeftTeamWins(0);
+    setRightTeamWins(0);
+    setErrorMessage("");
+    setVetos(Array(9).fill(null).map(() => createEmptyVeto()));
+  };
+
   useEffect(() => {
-    if (isEditing && selectedMatch) {
+    if (!open) {
+      loadedMatchIdRef.current = null;
+      return;
+    }
+
+    if (
+      isEditing &&
+      selectedMatch &&
+      loadedMatchIdRef.current !== selectedMatch.id
+    ) {
       setLeftTeamId(selectedMatch.left.id);
       setRightTeamId(selectedMatch.right.id);
       setLeftTeamWins(selectedMatch.left.wins);
       setRightTeamWins(selectedMatch.right.wins);
       setMatchType(selectedMatch.matchType);
-      setCurrentMatch(selectedMatch);
       setVetos(selectedMatch.vetos);
-    } else {
-      handleReset();
+      setErrorMessage("");
+      loadedMatchIdRef.current = selectedMatch.id;
+    } else if (!isEditing && loadedMatchIdRef.current !== "__new__") {
+      clearFormState();
+      loadedMatchIdRef.current = "__new__";
     }
-  }, [isEditing, selectedMatch]);
+  }, [open, isEditing, selectedMatch]);
 
   const validateForm = () => {
     let isValid = true;
@@ -77,6 +101,46 @@ export const MatchForm = ({ open, setOpen }: MatchFormProps) => {
     return isValid;
   };
 
+  const normalizeVetoForTeams = (
+    veto: Veto,
+    nextLeftTeamId: string | null,
+    nextRightTeamId: string | null,
+    previousLeftTeamId: string | null,
+    previousRightTeamId: string | null,
+  ): Veto => {
+    const score: Record<string, number> = {};
+
+    const leftScoreSourceId = nextLeftTeamId ?? previousLeftTeamId;
+    const rightScoreSourceId = nextRightTeamId ?? previousRightTeamId;
+
+    if (nextLeftTeamId && leftScoreSourceId && veto.score?.[leftScoreSourceId] !== undefined) {
+      score[nextLeftTeamId] = veto.score[leftScoreSourceId];
+    }
+
+    if (
+      nextRightTeamId &&
+      rightScoreSourceId &&
+      veto.score?.[rightScoreSourceId] !== undefined
+    ) {
+      score[nextRightTeamId] = veto.score[rightScoreSourceId];
+    }
+
+    const winner =
+      veto.winner === previousLeftTeamId && nextLeftTeamId
+        ? nextLeftTeamId
+        : veto.winner === previousRightTeamId && nextRightTeamId
+          ? nextRightTeamId
+          : veto.winner === nextLeftTeamId || veto.winner === nextRightTeamId
+            ? veto.winner
+            : undefined;
+
+    return {
+      ...veto,
+      winner,
+      score: Object.keys(score).length > 0 ? score : undefined,
+    };
+  };
+
   const handleVetoChange = (index: number, key: keyof Veto, value: any) => {
     const updatedVetos = [...vetos];
     updatedVetos[index] = { ...updatedVetos[index], [key]: value };
@@ -88,13 +152,23 @@ export const MatchForm = ({ open, setOpen }: MatchFormProps) => {
 
     setIsSubmitting(true);
 
+    const normalizedVetos = vetos.map((veto) =>
+      normalizeVetoForTeams(
+        veto,
+        leftTeamId,
+        rightTeamId,
+        selectedMatch?.left.id ?? null,
+        selectedMatch?.right.id ?? null,
+      ),
+    );
+
     const newMatch: Match = {
       id: selectedMatch?.id || "",
       left: { id: leftTeamId, wins: leftTeamWins },
       right: { id: rightTeamId, wins: rightTeamWins },
       matchType: matchType as "bo1" | "bo2" | "bo3" | "bo5",
       current: selectedMatch ? selectedMatch.current : false,
-      vetos: vetos,
+      vetos: normalizedVetos,
     };
 
     try {
@@ -120,25 +194,9 @@ export const MatchForm = ({ open, setOpen }: MatchFormProps) => {
   const handleReset = () => {
     setIsEditing(false);
     setSelectedMatch(null);
-    setLeftTeamId(null);
-    setRightTeamId(null);
-    setCurrentMatch(null);
-    setMatchType("bo1");
-    setLeftTeamWins(0);
-    setRightTeamWins(0);
-    setErrorMessage("");
-    const newVetos: Veto[] = vetos.map(() => ({
-      type: "pick",
-      teamId: "",
-      mapName: "",
-      side: "NO",
-      reverseSide: false,
-      mapEnd: false,
-    }));
-    setVetos(newVetos);
+    loadedMatchIdRef.current = null;
+    clearFormState();
   };
-
-  const vetoSource = selectedMatch?.vetos || vetos;
 
   return (
     <Dialog onClose={handleCancel} open={open}>
@@ -149,8 +207,8 @@ export const MatchForm = ({ open, setOpen }: MatchFormProps) => {
             : "Create Match"}
         </h3>
       </div>
-      <Container>
-        <div className="flex flex-1 flex-col overflow-y-scroll p-6">
+      <Container className="w-full min-h-0 items-stretch">
+        <div className="flex min-h-0 flex-1 flex-col overflow-auto p-6">
           <div className="my-2 flex items-center justify-center gap-4">
             <div className="bg-background-primary">
               <select
@@ -240,8 +298,8 @@ export const MatchForm = ({ open, setOpen }: MatchFormProps) => {
           </div>
 
           <h5 className="mt-4 font-semibold">Set Vetos:</h5>
-          {/* <div className="grid gap-2 md:grid-cols-2 lg:grid-cols-3"> */}
-          <table className="min-w-full divide-y divide-slate-400">
+          <div className="min-h-0 flex-1 overflow-auto">
+            <table className="min-w-max divide-y divide-slate-400">
             <thead className="bg-background-secondary">
               <tr>
                 <TableTH title="veto" />
@@ -250,10 +308,13 @@ export const MatchForm = ({ open, setOpen }: MatchFormProps) => {
                 <TableTH title="Map" />
                 <TableTH title="Side" />
                 <TableTH title="Reverse side" />
+                <TableTH title="Winner" />
+                <TableTH title="Score" />
+                <TableTH title="Finished" />
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-700 p-4">
-              {vetoSource.map((veto, index) => (
+              {vetos.map((veto, index) => (
                 <VetoRow
                   key={index}
                   index={index}
@@ -266,6 +327,7 @@ export const MatchForm = ({ open, setOpen }: MatchFormProps) => {
               ))}
             </tbody>
           </table>
+          </div>
         </div>
       </Container>
       <div className="inline-flex w-full justify-end gap-2 border-t border-border p-2">
@@ -296,7 +358,7 @@ interface TableTHProps {
 
 const TableTH: React.FC<TableTHProps> = ({ title }) => {
   return (
-    <th className="px-6 py-3 text-center text-xs font-medium uppercase tracking-wider text-gray-400">
+    <th className="min-w-28 px-6 py-3 text-center text-xs font-medium uppercase tracking-wider text-gray-400">
       {title}
     </th>
   );

--- a/src/UI/pages/Matches/MatchesTable.tsx
+++ b/src/UI/pages/Matches/MatchesTable.tsx
@@ -1,4 +1,11 @@
-import { MdPlayArrow, MdCancel, MdDelete, MdEdit, MdSwapHoriz } from "react-icons/md";
+import {
+  MdPlayArrow,
+  MdCancel,
+  MdDelete,
+  MdEdit,
+  MdSwapHoriz,
+  MdContentCopy,
+} from "react-icons/md";
 import { PrimaryButton } from "../../components/PrimaryButton";
 import { apiUrl } from "../../api/api";
 import { useMatches } from "../../hooks";
@@ -54,6 +61,8 @@ const MatchRow = ({ match, onEdit }: MatchRowProps) => {
   const { gameData } = useGameData();
   const [teamOne, setTeamOne] = React.useState<Team>();
   const [teamTwo, setTeamTwo] = React.useState<Team>();
+  const [copyState, setCopyState] = React.useState<"idle" | "copied" | "failed">("idle");
+  const [reverseBlink, setReverseBlink] = React.useState(false);
 
 
   React.useEffect(() => {
@@ -72,6 +81,26 @@ const MatchRow = ({ match, onEdit }: MatchRowProps) => {
     fetchTeams();
   }, [match]);
 
+  React.useEffect(() => {
+    if (copyState === "idle") return;
+
+    const timeout = window.setTimeout(() => {
+      setCopyState("idle");
+    }, 2000);
+
+    return () => window.clearTimeout(timeout);
+  }, [copyState]);
+
+  React.useEffect(() => {
+    if (!reverseBlink) return;
+
+    const timeout = window.setTimeout(() => {
+      setReverseBlink(false);
+    }, 300);
+
+    return () => window.clearTimeout(timeout);
+  }, [reverseBlink]);
+
   const handleEditClick = () => {
     if (onEdit) {
       onEdit(match);
@@ -81,6 +110,7 @@ const MatchRow = ({ match, onEdit }: MatchRowProps) => {
   const handleReverseSides = async () => {
     try {
       if (!gameData || !gameData.map || !gameData.map.name) return;
+      setReverseBlink(true);
       const mapName = gameData.map.name.substring(gameData.map.name.lastIndexOf("/") + 1);
       const veto = match.vetos.find((v) => v.mapName === mapName);
       if (!veto) return;
@@ -93,6 +123,54 @@ const MatchRow = ({ match, onEdit }: MatchRowProps) => {
       console.error("Failed to reverse sides on veto:", err);
     }
   };
+
+  const copyText = async (value: string) => {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(value);
+      return;
+    }
+
+    const textArea = document.createElement("textarea");
+    textArea.value = value;
+    textArea.setAttribute("readonly", "");
+    textArea.style.position = "absolute";
+    textArea.style.left = "-9999px";
+    document.body.appendChild(textArea);
+    textArea.select();
+    document.execCommand("copy");
+    document.body.removeChild(textArea);
+  };
+
+  const handleCopyHudLink = async () => {
+    const fallbackUrl = "http://localhost:1349/api/hud";
+
+    try {
+      const response = await fetch(`${apiUrl}/system/hud-url`);
+      const data = response.ok ? ((await response.json()) as { url?: string }) : null;
+      const url = data?.url || fallbackUrl;
+      await copyText(url);
+      setCopyState("copied");
+    } catch (error) {
+      try {
+        await copyText(fallbackUrl);
+        setCopyState("copied");
+      } catch {
+        setCopyState("failed");
+      }
+      console.error("Failed to copy HUD link:", error);
+    }
+  };
+
+  const copyTitle =
+    copyState === "copied"
+      ? "Copied HUD link"
+      : copyState === "failed"
+        ? "Copy failed"
+        : "Copy HUD link";
+  const copyButtonClass =
+    copyState === "idle" ? "" : "bg-background-light ring-2 ring-primary transition-all";
+  const reverseButtonClass =
+    reverseBlink ? "bg-background-light ring-2 ring-primary transition-all" : "";
 
   return (
     <tr id={"match_" + match.id}>
@@ -135,9 +213,17 @@ const MatchRow = ({ match, onEdit }: MatchRowProps) => {
                 <MdCancel className="size-6 text-secondary-light" />
               </PrimaryButton>
               <PrimaryButton
+                onClick={handleCopyHudLink}
+                title={copyTitle}
+                className={copyButtonClass}
+              >
+                <MdContentCopy className="size-6" />
+              </PrimaryButton>
+              <PrimaryButton
                 onClick={() => handleReverseSides()}
                 title="Reverse sides for current map veto"
                 disabled={!canReverseSides(match, gameData)}
+                className={reverseButtonClass}
               >
                 <MdSwapHoriz className="size-6" />
               </PrimaryButton>
@@ -146,9 +232,18 @@ const MatchRow = ({ match, onEdit }: MatchRowProps) => {
           currentMatch && currentMatch.id !== match.id ? (
             <></>
           ) : (
-            <PrimaryButton onClick={() => handleStartMatch(match.id)}>
-              <MdPlayArrow className="size-6" />
-            </PrimaryButton>
+            <>
+              <PrimaryButton onClick={handleStartMatch.bind(null, match.id)}>
+                <MdPlayArrow className="size-6" />
+              </PrimaryButton>
+              <PrimaryButton
+                onClick={handleCopyHudLink}
+                title={copyTitle}
+                className={copyButtonClass}
+              >
+                <MdContentCopy className="size-6" />
+              </PrimaryButton>
+            </>
           )
         )}
             <PrimaryButton onClick={() => handleEditClick()}>

--- a/src/UI/pages/Matches/VetoRow.tsx
+++ b/src/UI/pages/Matches/VetoRow.tsx
@@ -20,15 +20,39 @@ export const VetoRow: React.FC<VetoRowProps> = ({
 }) => {
   const leftTeam = teams.find((team) => team._id === leftTeamId);
   const rightTeam = teams.find((team) => team._id === rightTeamId);
+  const leftScore = leftTeamId ? veto.score?.[leftTeamId] ?? "" : "";
+  const rightScore = rightTeamId ? veto.score?.[rightTeamId] ?? "" : "";
+
+  const handleScoreChange = (
+    teamId: string | null,
+    value: string,
+    otherTeamId: string | null,
+  ) => {
+    if (!teamId) return;
+
+    const nextScore: Record<string, number> = {};
+
+    if (otherTeamId && veto.score?.[otherTeamId] !== undefined) {
+      nextScore[otherTeamId] = veto.score[otherTeamId];
+    }
+
+    if (value !== "") {
+      nextScore[teamId] = Number(value);
+    }
+
+    onVetoChange(
+      index,
+      "score",
+      Object.keys(nextScore).length > 0 ? nextScore : undefined,
+    );
+  };
 
   return (
-    <tr
-      className="bg-background-secondary odd:bg-background-primary"
-    >
-      <td className="px-6 py-4">
+    <tr className="bg-background-secondary odd:bg-background-primary">
+      <td className="min-w-24 px-6 py-4">
         <h4 className="text-center font-semibold">Veto {index + 1}</h4>
       </td>
-      <td className="px-6 py-4">
+      <td className="min-w-32 px-6 py-4">
         <form className="flex w-full flex-col">
           <div className="flex w-full flex-col justify-center space-y-1">
             {["pick", "ban", "decider"].map((option) => (
@@ -53,7 +77,7 @@ export const VetoRow: React.FC<VetoRowProps> = ({
           </div>
         </form>
       </td>
-      <td className="px-6 py-4">
+      <td className="min-w-36 px-6 py-4">
         <div className="w-full">
           <select
             disabled={veto.type === "decider"}
@@ -76,7 +100,7 @@ export const VetoRow: React.FC<VetoRowProps> = ({
           </select>
         </div>
       </td>
-      <td className="px-6 py-4">
+      <td className="min-w-36 px-6 py-4">
         <div className="w-full">
           <select
             value={veto.mapName || ""}
@@ -96,7 +120,7 @@ export const VetoRow: React.FC<VetoRowProps> = ({
           </select>
         </div>
       </td>
-      <td className="px-6 py-4">
+      <td className="min-w-28 px-6 py-4">
         <div className="w-full">
           <select
             value={veto.side}
@@ -112,13 +136,67 @@ export const VetoRow: React.FC<VetoRowProps> = ({
           </select>
         </div>
       </td>
-      <td className="px-6 py-4">
+      <td className="min-w-24 px-6 py-4">
         <div className="col-span-2 flex w-full flex-col items-center justify-center">
           <input
             type="checkbox"
             id={`reverseSide-${index}`}
             checked={veto.reverseSide === true}
             onChange={(e) => onVetoChange(index, "reverseSide", e.target.checked)}
+          />
+        </div>
+      </td>
+      <td className="min-w-36 px-6 py-4">
+        <div className="w-full">
+          <select
+            value={veto.winner || ""}
+            onChange={(e) =>
+              onVetoChange(index, "winner", e.target.value || undefined)
+            }
+            name="Winner"
+          >
+            <option value="">No winner</option>
+            {leftTeamId && leftTeam && (
+              <option value={leftTeamId}>{leftTeam.name}</option>
+            )}
+            {rightTeamId && rightTeam && (
+              <option value={rightTeamId}>{rightTeam.name}</option>
+            )}
+          </select>
+        </div>
+      </td>
+      <td className="min-w-32 px-6 py-4">
+        <div className="flex items-center justify-center gap-2">
+          <input
+            type="number"
+            min={0}
+            className="h-8 w-16 rounded border border-gray-300 px-2 text-center"
+            value={leftScore}
+            onChange={(e) =>
+              handleScoreChange(leftTeamId, e.target.value, rightTeamId)
+            }
+            aria-label={`Left score for veto ${index + 1}`}
+          />
+          <span>-</span>
+          <input
+            type="number"
+            min={0}
+            className="h-8 w-16 rounded border border-gray-300 px-2 text-center"
+            value={rightScore}
+            onChange={(e) =>
+              handleScoreChange(rightTeamId, e.target.value, leftTeamId)
+            }
+            aria-label={`Right score for veto ${index + 1}`}
+          />
+        </div>
+      </td>
+      <td className="min-w-24 px-6 py-4">
+        <div className="flex w-full items-center justify-center">
+          <input
+            type="checkbox"
+            id={`mapEnd-${index}`}
+            checked={veto.mapEnd}
+            onChange={(e) => onVetoChange(index, "mapEnd", e.target.checked)}
           />
         </div>
       </td>

--- a/src/electron/api/v2/api.router.ts
+++ b/src/electron/api/v2/api.router.ts
@@ -8,6 +8,7 @@ import { HudRoutes } from "./huds/huds.routes.js";
 import { readGameData } from "./gsi/gsi.js";
 import { cameraRoutes } from "./cameras/cameras.routes.js";
 import { coachRoutes } from "./coaches/coaches.routes.js";
+import { getHudUrlHandler } from "./system/system.controller.js";
 
 export const APIRouter = Router();
 
@@ -19,5 +20,6 @@ APIRouter.use("/coach", coachRoutes);
 APIRouter.use("/tournament", tournmentRoutes);
 APIRouter.use("/camera", cameraRoutes);
 APIRouter.get("/radar/maps", getMapsHandler);
+APIRouter.get("/system/hud-url", getHudUrlHandler);
 APIRouter.use("/hud", HudRoutes);
 APIRouter.post("/gsi", readGameData);

--- a/src/electron/api/v2/system/system.controller.ts
+++ b/src/electron/api/v2/system/system.controller.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from "express";
+import os from "os";
+
+const getLocalIPv4 = (): string | null => {
+  const interfaces = os.networkInterfaces();
+
+  for (const networkInterface of Object.values(interfaces)) {
+    if (!networkInterface) continue;
+
+    for (const address of networkInterface) {
+      if (address.family === "IPv4" && !address.internal) {
+        return address.address;
+      }
+    }
+  }
+
+  return null;
+};
+
+export const getHudUrlHandler = (_req: Request, res: Response) => {
+  const host = getLocalIPv4() ?? "localhost";
+  res.status(200).json({
+    url: `http://${host}:1349/api/hud`,
+  });
+};


### PR DESCRIPTION
Allow operators to manually set per-map winners, scores, and finished state in the match update dialog so previous match results can be corrected when automatic updates fail.

Fix match dialog UI state issues so edits are reflected immediately before submit, and improve dialog/table scrolling and layout behavior.

Add a copy-link action for the HUD overlay URL from the matches view.